### PR TITLE
updated API documentation to include "none" as an accepted parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ update(book, shelf)
 ```
 
 * book: `<Object>` containing at minimum an `id` attribute
-* shelf: `<String>` contains one of ["wantToRead", "currentlyReading", "read"]  
+* shelf: `<String>` contains one of ["wantToRead", "currentlyReading", "read", "none"]  
 * Returns a Promise which resolves to a JSON object containing the response data of the POST request
 
 ### `search`


### PR DESCRIPTION
API documentation does not say that "none" is an acceptable parameter, to remove a book from all bookshelves.