### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The backend API uses a fixed set of cached search results and is limited to a pa
 
 ## Create React App
 
-This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app). You can find more information on how to perform common tasks [here](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
+This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app). You can find more information on how to perform common tasks [here]( https://github.com/facebook/create-react-app/blob/master/packages/cra-template/template/README.md).
 
 ## Contributing
 


### PR DESCRIPTION
Updated broken link to place where the link was moved to.

 The README linked to was recently moved via https://github.com/facebook/create-react-app/commit/4c0c81953d090dbf122e126f2b6b8c803d4a0569

The new link is https://github.com/facebook/create-react-app/blob/master/packages/cra-template/template/README.md

Note that I also replaced `facebookincubator` that's in the original link with `facebook` because links with `facebookincubator` as the account now redirect to use the `facebook` account instead
